### PR TITLE
Remote repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Note that by default "oc new-app" will detect the name of the remote repo and us
 This will not work if you have 2-factor auth setup on Github. In that case, create a [Personal Access Token with no scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/)
 You'll also need to add your Personal Access Token to the OpenShift project:
 
-* oc secret new-basicauth user-at-github --username=dbacker-rh --prompt
+* oc secret new-basicauth user-at-github --username=dbaker-rh --prompt
 Password:
 secret/user-at-github
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Note that by default "oc new-app" will detect the name of the remote repo and us
 
 * git clone https://github.com/dbaker-rh/container-diags.git && cd ./container-diags
 * ... edit, as needed, ...
+* git commit -am 'needed changes'
+* git push
 * oc login ...
 * oc new-project foo
 * oc new-app .
@@ -29,6 +31,17 @@ Note that by default "oc new-app" will detect the name of the remote repo and us
 * oc rsh $( oc get pods | awk '$1!~/-build/ && $3=="Running" {print $1; exit}' ) bash
 *
 
+
+This will not work if you have 2-factor auth setup on Github. In that case, create a [Personal Access Token with no scope](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/)
+You'll also need to add your Personal Access Token to the OpenShift project:
+
+* oc secret new-basicauth user-at-github --username=dbacker-rh --prompt
+Password:
+secret/user-at-github
+
+* oc secrets link builder user-at-github
+* oc annotate secret/user-at-github \
+    'build.openshift.io/source-secret-match-uri-1=https://github.com/dbaker-rh/container-diags.git'
 
 ## From a local directory
 


### PR DESCRIPTION
When a local clone of the repo, local changes won't be sent using 'oc new-app .'. You need to commit your changes to the remote before any changes will be build in OpenShift.

Also, if you've got 2-Factor auth enabled on Github, HTTPS repos will require you to use a Personal Access Token embedded as a secret in the OpenShift project.