### PR TITLE
switched to centos repo to avoid problems with docker rate limiting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/centos:7
+FROM registry.centos.org/centos:7
 MAINTAINER Dave Baker <dbaker@redhat.com>
 
 # Quick-start:


### PR DESCRIPTION
On a 3.11 cluster I hit the docker hub rate limit. Switching to Centos image registry to avoid that problem. 

Centos image registry is also listed as the canonical source in the new container-tools [shortname feature](https://github.com/containers/shortnames/blob/main/shortnames.conf).